### PR TITLE
parser: make anyDetails more explicit

### DIFF
--- a/pkg/parse/parser.go
+++ b/pkg/parse/parser.go
@@ -93,6 +93,11 @@ func UnmarshalAny(buf []byte, details *AnyDetails) (*ubp.Blueprint, error) {
 	bpJSON, bpWarnJSON := imJSON.Import()
 	details.bpCountJSON = countSetFieldsRecursive(bpJSON)
 
+	// XXX: can we archive this with strict unmarshal?
+	// i.e. make json use Decoder.DisallowUnknownFields
+	// check in toml for unconverted fields and use
+	// yaml.UnmarshalStrict() ? i.e. why do we need the counting
+	// here otherwise?
 	maxCount := max(details.ubpCountYAML, details.ubpCountJSON, details.bpCountTOML, details.bpCountJSON)
 	err := errors.Join(
 		fmt.Errorf("YAML: %w", ubpErrYAML),


### PR DESCRIPTION
The current `anyDetails ...*AnyDetails` is a bit loose, ie. it will allow to pass multiple anyDetails but only the first is used. Just remove the `...` so that it becomes a static compiler check (passing `nil` here is fine).

The alternative would be to do a runtime error if multiple AnyDetails are passed but that static checks seems slightly nicer (but its an option).

---

fixup! add question about parsing
