### PR TITLE
github: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence.
+*               @osbuild/osbuild-reviewers @lzap


### PR DESCRIPTION
Add the osbuild-reviewers team and Lukas Zapletal as code owners of the project.  These people will automatically assigned as reviewers on PRs.