### PR TITLE
blueprint: new customization: dnf.config

### DIFF
--- a/pkg/ubp/types.gen.go
+++ b/pkg/ubp/types.gen.go
@@ -334,6 +334,8 @@ type Container struct {
 // to freeze the blueprint. This is because the provides will expand into multiple
 // packages with their own names and versions.
 type DNF struct {
+	DNFConfig DNFConfig `json:"config,omitempty,omitzero"`
+
 	// Groups Groups to install, must match exactly. Groups describes groups
 	// of packages to be installed into the image. Package groups are defined
 	// in the repository metadata. Each group has a descriptive name used primarily
@@ -366,6 +368,16 @@ type DNF struct {
 	//
 	// All fields reflect configuration values of dnf, see man dnf.conf(5) for more information.
 	Repositories []DNFRepository `json:"repositories,omitempty,omitzero"`
+}
+
+// DNFConfig defines model for dnf_config.
+type DNFConfig struct {
+	// SetReleasever Set the $releasever DNF variable to the distribution's release.  On RHEL
+	// systems, this ties a system to a specific release, preventing it from
+	// being updated to a later minor RHEL release through 'dnf upgrade', and is
+	// the mechanism for keeping systems on extended support releases (EUS and
+	// E4S).
+	SetReleasever bool `json:"set_releasever,omitempty,omitzero"`
 }
 
 // DNFRepository defines model for dnf_repository.

--- a/schema/blueprint-oas3-ext.json
+++ b/schema/blueprint-oas3-ext.json
@@ -328,6 +328,9 @@
         "additionalProperties": false,
         "description": "DNF package managers details. When using virtual provides as the\npackage name the version glob should be *. And be aware that you will be unable\nto freeze the blueprint. This is because the provides will expand into multiple\npackages with their own names and versions.\n",
         "properties": {
+          "config": {
+            "$ref": "#/components/schemas/dnf_config"
+          },
           "groups": {
             "description": "Groups to install, must match exactly. Groups describes groups\nof packages to be installed into the image. Package groups are defined\nin the repository metadata. Each group has a descriptive name used primarily\nfor display in user interfaces and an ID more commonly used in kickstart\nfiles. Here, the ID is the expected way of listing a group. Groups have\nthree different ways of categorizing their packages: mandatory, default,\nand optional. For the purposes of blueprints, only mandatory and default\npackages will be installed. There is no mechanism for selecting optional\npackages.\n",
             "items": {
@@ -371,6 +374,19 @@
         },
         "type": "object",
         "x-go-name": "DNF",
+        "x-omitempty": true
+      },
+      "dnf_config": {
+        "additionalProperties": false,
+        "properties": {
+          "set_releasever": {
+            "description": "Set the $releasever DNF variable to the distribution's release.  On RHEL\nsystems, this ties a system to a specific release, preventing it from\nbeing updated to a later minor RHEL release through 'dnf upgrade', and is\nthe mechanism for keeping systems on extended support releases (EUS and\nE4S).\n",
+            "type": "boolean",
+            "x-go-name": "SetReleasever"
+          }
+        },
+        "type": "object",
+        "x-go-name": "DNFConfig",
         "x-omitempty": true
       },
       "dnf_repository": {

--- a/schema/blueprint-oas3.json
+++ b/schema/blueprint-oas3.json
@@ -328,6 +328,9 @@
         "additionalProperties": false,
         "description": "DNF package managers details. When using virtual provides as the\npackage name the version glob should be *. And be aware that you will be unable\nto freeze the blueprint. This is because the provides will expand into multiple\npackages with their own names and versions.\n",
         "properties": {
+          "config": {
+            "$ref": "#/components/schemas/dnf_config"
+          },
           "groups": {
             "description": "Groups to install, must match exactly. Groups describes groups\nof packages to be installed into the image. Package groups are defined\nin the repository metadata. Each group has a descriptive name used primarily\nfor display in user interfaces and an ID more commonly used in kickstart\nfiles. Here, the ID is the expected way of listing a group. Groups have\nthree different ways of categorizing their packages: mandatory, default,\nand optional. For the purposes of blueprints, only mandatory and default\npackages will be installed. There is no mechanism for selecting optional\npackages.\n",
             "items": {
@@ -371,6 +374,19 @@
         },
         "type": "object",
         "x-go-name": "DNF",
+        "x-omitempty": true
+      },
+      "dnf_config": {
+        "additionalProperties": false,
+        "properties": {
+          "set_releasever": {
+            "description": "Set the $releasever DNF variable to the distribution's release.  On RHEL\nsystems, this ties a system to a specific release, preventing it from\nbeing updated to a later minor RHEL release through 'dnf upgrade', and is\nthe mechanism for keeping systems on extended support releases (EUS and\nE4S).\n",
+            "type": "boolean",
+            "x-go-name": "SetReleasever"
+          }
+        },
+        "type": "object",
+        "x-go-name": "DNFConfig",
         "x-omitempty": true
       },
       "dnf_repository": {

--- a/schema/blueprint-oas3.yaml
+++ b/schema/blueprint-oas3.yaml
@@ -339,6 +339,8 @@ components:
         to freeze the blueprint. This is because the provides will expand into multiple
         packages with their own names and versions.
       properties:
+        config:
+          $ref: '#/components/schemas/dnf_config'
         groups:
           description: |
             Groups to install, must match exactly. Groups describes groups
@@ -394,6 +396,21 @@ components:
           x-omitempty: true
       type: object
       x-go-name: DNF
+      x-omitempty: true
+    dnf_config:
+      additionalProperties: false
+      properties:
+        set_releasever:
+          description: |
+            Set the $releasever DNF variable to the distribution's release.  On RHEL
+            systems, this ties a system to a specific release, preventing it from
+            being updated to a later minor RHEL release through 'dnf upgrade', and is
+            the mechanism for keeping systems on extended support releases (EUS and
+            E4S).
+          type: boolean
+          x-go-name: SetReleasever
+      type: object
+      x-go-name: DNFConfig
       x-omitempty: true
     dnf_repository:
       additionalProperties: false

--- a/schema/oas/components/dnf.yaml
+++ b/schema/oas/components/dnf.yaml
@@ -64,4 +64,6 @@ properties:
     items:
       "$ref": "dnf_repository.yaml"
     x-omitempty: true
+  config:
+    "$ref": "dnf_config.yaml"
 additionalProperties: false

--- a/schema/oas/components/dnf_config.yaml
+++ b/schema/oas/components/dnf_config.yaml
@@ -1,0 +1,15 @@
+---
+type: object
+x-go-name: DNFConfig
+x-omitempty: true
+properties:
+  set_releasever:
+    description: |
+      Set the $releasever DNF variable to the distribution's release.  On RHEL
+      systems, this ties a system to a specific release, preventing it from
+      being updated to a later minor RHEL release through 'dnf upgrade', and is
+      the mechanism for keeping systems on extended support releases (EUS and
+      E4S).
+    type: boolean
+    x-go-name: SetReleasever
+additionalProperties: false

--- a/testdata/all-fields.in.yaml
+++ b/testdata/all-fields.in.yaml
@@ -35,6 +35,8 @@ dnf:
       usage:
         install: false
         configure: false
+  config:
+    set_releasever: true
 containers:
   - source: "quay.io/fedora/fedora:latest"
     name: "fedora"

--- a/testdata/valid-dnf.in.yaml
+++ b/testdata/valid-dnf.in.yaml
@@ -21,3 +21,5 @@ dnf:
       usage:
         install: true
         configure: true
+  config:
+    set_releasever: true


### PR DESCRIPTION
New dnf.config customization block that enables one option for now: set_releasever.  The option is meant to set the releasever dnf variable to the value of the distro's release version, which ties a system to a specific update of RHEL.  This prevents a system from being updated to a later minor RHEL release through `dnf upgrade` and is the mechanism for keeping systems on extended support releases (EUS and E4S).

The dnf customization block is created so that it might later be used for other variables (perhaps even arbitrary, user-defined variables).  However, the releasever variable will be treated separately so that it can be a simple switch that sets the `releasever` value to the one for the image's distro dynamically.

The config key `set_releasever` was chosen over `set_release_ver` because the variable name is `releasever` and it is more consistent with other user-facing use cases where it is treated as a single word.


---

Counterpart to https://github.com/osbuild/blueprint/pull/34